### PR TITLE
Change lambda workers from 700 to 500

### DIFF
--- a/data/env.py
+++ b/data/env.py
@@ -26,4 +26,4 @@ SCAN_RESULTS = os.path.join(SCAN_DATA, 'results')
 SCANNERS = ["pshtt", "sslyze"]
 
 # Used if --lambda is enabled during the scan.
-LAMBDA_WORKERS = 700
+LAMBDA_WORKERS = 500


### PR DESCRIPTION
In spite of the fact that the worker limit should be 1000, with 700 we
are still experiencing the occasional error from too many simultanious
workers when doing a lambda scan.

500 has so far never resulted in such an error.