### PR TITLE
Badge cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
-CircleCI Status: [![CircleCI](https://circleci.com/gh/cds-snc/tracker.svg?style=svg)](https://circleci.com/gh/cds-snc/tracker)
-[![Known Vulnerabilities](https://snyk.io/test/github/cds-snc/tracker/badge.svg)](https://snyk.io/test/github/cds-snc/tracker)
-
+CircleCI Status: [![CircleCI](https://circleci.com/gh/cds-snc/tracker.svg?style=svg)](https://circleci.com/gh/cds-snc/tracker)  
+Snyk Vulnerabilities: [![Known Vulnerabilities](https://snyk.io/test/github/cds-snc/tracker/badge.svg)](https://snyk.io/test/github/cds-snc/tracker)
 
 ## Track Government of Canada domains's adherance to digital security practices
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-CircleCI Status: [![CircleCI](https://circleci.com/gh/cds-snc/tracker.svg?style=svg)](https://circleci.com/gh/cds-snc/tracker)  
-Snyk Vulnerabilities: [![Known Vulnerabilities](https://snyk.io/test/github/cds-snc/tracker/badge.svg)](https://snyk.io/test/github/cds-snc/tracker)
+[![CircleCI](https://circleci.com/gh/cds-snc/tracker.svg?style=svg)](https://circleci.com/gh/cds-snc/tracker)
+[![Known Vulnerabilities](https://snyk.io/test/github/cds-snc/tracker/badge.svg)](https://snyk.io/test/github/cds-snc/tracker)
 
 ## Track Government of Canada domains's adherance to digital security practices
 


### PR DESCRIPTION
This PR removes the text preceeding the badges on the README.

With more than one badge, it is incorrect to say that the badges just represent "CircleCI Status".
I looked around on some other repositories and it seems to be common practice to simply list the badges on one line at the top of the README with no text.