### PR TITLE
domain-scan is 3.6+, that means we are too

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,20 +29,10 @@ jobs:
     working_directory: ~/repo
   build_package:
     docker:
-      - image: ubuntu:xenial
+      - image: cdssnc/tracker-build:0.1.0
     working_directory: /home/DEV.T1.TBS-SCT.GC.CA/dsamojle-ps
     steps:
       - checkout
-      - restore_cache:
-          key: "deps1-{{ .Branch }}-{{ checksum \"deploy/provision.sh\" }}"
-      - run:
-          command: sh deploy/provision.sh
-          name: "Provisioning build environment"
-      - save_cache:
-          key: "deps1-{{ .Branch }}-{{ checksum \"deploy/provision.sh\" }}"
-          paths:
-            - /usr/local/bin/python3.6
-            - /usr/local/lib/python3.6
       - run:
           command: sh deploy/build-env.sh
           name: "Building the package"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,6 +57,6 @@ workflows:
       - build_package:
          requires:
             - tracker
-#         filters:
-#           branches:
-#             only: master
+         filters:
+           branches:
+             only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,36 +27,8 @@ jobs:
               pytest --cov=data tests
           name: "Running tests"
     working_directory: ~/repo
-  build_package:
-    docker:
-      - image: ubuntu:xenial
-    working_directory: /home/DEV.T1.TBS-SCT.GC.CA/dsamojle-ps
-    steps:
-      - checkout
-      - restore_cache:
-          key: "deps1-{{ .Branch }}-{{ checksum \"deploy/provision.sh\" }}"
-      - run:
-          command: sh deploy/provision.sh
-          name: "Provisioning build environment"
-      - save_cache:
-          key: "deps1-{{ .Branch }}-{{ checksum \"deploy/provision.sh\" }}"
-          paths:
-            - /usr/local/bin/python3.6
-            - /usr/local/lib/python3.6
-      - run:
-          command: sh deploy/build-env.sh
-          name: "Building the package"
-      - store_artifacts:
-          path: /home/DEV.T1.TBS-SCT.GC.CA/dsamojle-ps/tracker.tar.gz
-          destination: tracker.tar.gz
 workflows:
   version: 2
   tracker:
     jobs:
       - tracker
-      - build_package:
-         requires:
-            - tracker
-         filters:
-           branches:
-             only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,10 +33,19 @@ jobs:
     working_directory: /home/DEV.T1.TBS-SCT.GC.CA/dsamojle-ps
     steps:
       - checkout
+      - restore_cache:
+          key: "deps1-{{ .Branch }}-{{ checksum \"deploy/provision.sh\" }}"
       - run:
-          command: |
-              sh deploy/provision.sh
-              sh deploy/build-env.sh
+          command: sh deploy/provision.sh
+          name: "Provisioning build environment"
+      - save_cache:
+          key: "deps1-{{ .Branch }}-{{ checksum \"deploy/provision.sh\" }}"
+          paths:
+            - /usr/local/bin/python3.6
+            - /usr/local/lib/python3.6
+      - run:
+          command: sh deploy/build-env.sh
+          name: "Building the package"
       - store_artifacts:
           path: /home/DEV.T1.TBS-SCT.GC.CA/dsamojle-ps/tracker.tar.gz
           destination: tracker.tar.gz

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 jobs:
   tracker:
     docker:
-      - image: "circleci/python:3.5.5"
+      - image: "circleci/python:3.6"
       - image: "mongo:3.6.2"
     steps:
       - checkout:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,8 +27,36 @@ jobs:
               pytest --cov=data tests
           name: "Running tests"
     working_directory: ~/repo
+  build_package:
+    docker:
+      - image: ubuntu:xenial
+    working_directory: /home/DEV.T1.TBS-SCT.GC.CA/dsamojle-ps
+    steps:
+      - checkout
+      - restore_cache:
+          key: "deps1-{{ .Branch }}-{{ checksum \"deploy/provision.sh\" }}"
+      - run:
+          command: sh deploy/provision.sh
+          name: "Provisioning build environment"
+      - save_cache:
+          key: "deps1-{{ .Branch }}-{{ checksum \"deploy/provision.sh\" }}"
+          paths:
+            - /usr/local/bin/python3.6
+            - /usr/local/lib/python3.6
+      - run:
+          command: sh deploy/build-env.sh
+          name: "Building the package"
+      - store_artifacts:
+          path: /home/DEV.T1.TBS-SCT.GC.CA/dsamojle-ps/tracker.tar.gz
+          destination: tracker.tar.gz
 workflows:
   version: 2
   tracker:
     jobs:
       - tracker
+      - build_package:
+         requires:
+            - tracker
+         filters:
+           branches:
+             only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,23 +35,8 @@ jobs:
       - checkout
       - run:
           command: |
-              apt-get update
-              apt-get install -y python3 python3-venv python3-dev build-essential wget
-              apt-get install -y python3-pip locales
-              locale-gen en_US.UTF-8
-              export LANG="en_US:en"
-              export LANGUAGE="en_US: en"
-              export LC_ALL="en_US.UTF-8"
-
-              mkdir -p domain-scan && wget -q -O - https://api.github.com/repos/18F/domain-scan/tarball | tar xz --strip-components=1 -C domain-scan
-              python3 -m venv .venv
-              . .venv/bin/activate
-              pip install --upgrade pip
-              pip install -r requirements.txt
-              pip install -r domain-scan/requirements.txt
-              pip install -r domain-scan/requirements-scanners.txt
-              pip install .
-              tar -czvf tracker.tar.gz .venv domain-scan
+              sh deploy/provision.sh
+              sh deploy/build-env.sh
       - store_artifacts:
           path: /home/DEV.T1.TBS-SCT.GC.CA/dsamojle-ps/tracker.tar.gz
           destination: tracker.tar.gz

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,6 +57,6 @@ workflows:
       - build_package:
          requires:
             - tracker
-         filters:
-           branches:
-             only: master
+#         filters:
+#           branches:
+#             only: master

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,13 +1,6 @@
 FROM ubuntu:16.04
-RUN ["apt-get", "update"]
-RUN ["apt-get", "install", "-y", "python3", "python3-venv", "python3-dev", "build-essential", "wget"]
-RUN ["apt-get", "install", "-y", "locales", "python3-pip"]
+COPY deploy/provision.sh /opt/provision.sh
+RUN sh /opt/provision.sh
+
 COPY deploy/build-env.sh /opt/build-env.sh
-
-# Set the locale - needed so the installation of publicsuffixlist does not fail
-RUN ["locale-gen", "en_US.UTF-8"]
-ENV LANG en_US.UTF-8
-ENV LANGUAGE en_US:en
-ENV LC_ALL en_US.UTF-8
-
 CMD ["sh", "/opt/build-env.sh", "/home/DEV.T1.TBS-SCT.GC.CA/dsamojle-ps/"]

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ If you are developing this and add an aditional dependency, make sure to add it 
 
 For development purposes it is recommended that you install [mongodb](https://www.mongodb.com/) and run the database locally.
 
-This utility is written for **Python 3.5 and up**. We recommend [pyenv](https://github.com/yyuu/pyenv) for easy Python version management.
+This utility is written for **Python 3.6 and up**. We recommend [pyenv](https://github.com/yyuu/pyenv) for easy Python version management.
 
 To setup local python dependencies you can run `make setup` from the root of the repository. We recommend that this is done from within a virtual environment
 

--- a/deploy/build-env.sh
+++ b/deploy/build-env.sh
@@ -7,7 +7,7 @@ export LANG=en_US.UTF-8
 export LANGUAGE=en_US:en
 export LC_ALL=en_US.UTF-8
 
-python3.6 -m venv --copies .venv
+python3.6 -m venv .venv
 mkdir -p domain-scan && wget -q -O - https://api.github.com/repos/18F/domain-scan/tarball | tar xz --strip-components=1 -C domain-scan
 
 . .venv/bin/activate

--- a/deploy/build-env.sh
+++ b/deploy/build-env.sh
@@ -1,7 +1,13 @@
 WORKDIR=${1:-"/home/DEV.T1.TBS-SCT.GC.CA/dsamojle-ps/"}
 mkdir -p $WORKDIR
 cd $WORKDIR
-python3 -m venv .venv
+
+# Configure Locale so publicsuffixlist doesn't fail on installation
+export LANG=en_US.UTF-8
+export LANGUAGE=en_US:en
+export LC_ALL=en_US.UTF-8
+
+python3.6 -m venv --copies .venv
 mkdir -p domain-scan && wget -q -O - https://api.github.com/repos/18F/domain-scan/tarball | tar xz --strip-components=1 -C domain-scan
 
 . .venv/bin/activate

--- a/deploy/provision.sh
+++ b/deploy/provision.sh
@@ -1,0 +1,20 @@
+# Install dependencies
+apt-get update && apt-get install -y \
+build-essential \
+checkinstall \
+libffi-dev \
+libssl-dev \
+locales \
+python3-dev \
+wget \
+zlib1g-dev 
+                                                                   
+# Generate UTF-8 localte for publicsuffixlist install
+locale-gen en_US.UTF-8
+
+# Build and install Python3.6
+cd /opt
+wget https://www.python.org/ftp/python/3.6.6/Python-3.6.6.tgz
+tar -xvf Python-3.6.6.tgz
+cd Python-3.6.6
+./configure --enable-optimizations && make && make install


### PR DESCRIPTION
This PR makes some changes to test against/build/use python3.6 since https://github.com/18F/domain-scan/pull/262 domain-scan is 3.6+, meaning we are too by necessity.

 