### PR TITLE
Refactor logger module

### DIFF
--- a/data/logger.py
+++ b/data/logger.py
@@ -19,6 +19,8 @@ _stream_handler.setFormatter(_formatter)
 logging.getLogger().addHandler(_syslog_handler)
 logging.getLogger().addHandler(_stream_handler)
 
+# https://codereview.stackexchange.com/questions/6567/redirecting-subprocesses-output-stdout-and-stderr-to-the-logging-module
+# To redirect stderr & stdout from subprocess calls into a logger
 class LogPipe(threading.Thread):
 
     def __init__(self, logger, level):

--- a/data/logger.py
+++ b/data/logger.py
@@ -10,12 +10,15 @@ _syslog_handler.setLevel(logging.ERROR)
 _stream_handler = logging.StreamHandler()
 _stream_handler.setLevel(logging.INFO)
 
-_formatter = logging.Formatter(
+_stream_formatter = logging.Formatter(
     fmt="%(asctime)s - %(levelname)s - %(name)s: %(message)s",
     datefmt="%Y-%m-%dT%H:%M:%S%z",
 )
-_syslog_handler.setFormatter(_formatter)
-_stream_handler.setFormatter(_formatter)
+_syslog_formatter = logging.Formatter(
+    fmt="%(name)s: [%(levelname)s] %(message)s",
+)
+_syslog_handler.setFormatter(_syslog_formatter)
+_stream_handler.setFormatter(_stream_formatter)
 logging.getLogger().addHandler(_syslog_handler)
 logging.getLogger().addHandler(_stream_handler)
 

--- a/data/logger.py
+++ b/data/logger.py
@@ -1,5 +1,6 @@
 import logging
 from logging.handlers import SysLogHandler
+import threading
 import os
 
 # Configure the root logger with handlers
@@ -17,6 +18,39 @@ _syslog_handler.setFormatter(_formatter)
 _stream_handler.setFormatter(_formatter)
 logging.getLogger().addHandler(_syslog_handler)
 logging.getLogger().addHandler(_stream_handler)
+
+class LogPipe(threading.Thread):
+
+    def __init__(self, logger, level):
+        """Setup the object with a logger and a loglevel
+        and start the thread
+        """
+        super(LogPipe, self).__init__()
+        self.daemon = False
+        self.logger = logger
+        self.level = level
+        self.fd_read, self.fd_write = os.pipe()
+        self.pipe_reader = os.fdopen(self.fd_read, encoding='utf-8', errors='ignore')
+        self.start()
+
+    def fileno(self):
+        """Return the write file descriptor of the pipe
+        """
+        return self.fd_write
+
+    def run(self):
+        """Run the thread, logging everything.
+        """
+        for line in iter(self.pipe_reader.readline, ''):
+            self.logger.log(self.level, line.strip('\n'))
+
+        self.pipe_reader.close()
+
+    def close(self):
+        """Close the write end of the pipe.
+        """
+        os.close(self.fd_write)
+
 
 def unwrap_exception_message(exc: BaseException, join: str = " - ") -> str:
     if exc.__context__:

--- a/data/logger.py
+++ b/data/logger.py
@@ -1,5 +1,22 @@
 import logging
+from logging.handlers import SysLogHandler
+import os
 
+# Configure the root logger with handlers
+_syslog_handler = SysLogHandler(address=os.environ.get("TRACKER_SYSLOG", "/dev/log"))
+_syslog_handler.setLevel(logging.ERROR)
+
+_stream_handler = logging.StreamHandler()
+_stream_handler.setLevel(logging.INFO)
+
+_formatter = logging.Formatter(
+    fmt="%(asctime)s - %(levelname)s - %(name)s: %(message)s",
+    datefmt="%Y-%m-%dT%H:%M:%S%z",
+)
+_syslog_handler.setFormatter(_formatter)
+_stream_handler.setFormatter(_formatter)
+logging.getLogger().addHandler(_syslog_handler)
+logging.getLogger().addHandler(_stream_handler)
 
 def unwrap_exception_message(exc: BaseException, join: str = " - ") -> str:
     if exc.__context__:
@@ -12,14 +29,5 @@ def unwrap_exception_message(exc: BaseException, join: str = " - ") -> str:
 def get_logger(name: str) -> logging.Logger:
     logger = logging.getLogger(name)
     logger.setLevel(logging.INFO)
-
-    if not logger.hasHandlers():
-        handler = logging.StreamHandler()
-        formatter = logging.Formatter(
-            fmt="%(asctime)s - %(levelname)s - %(name)s: %(message)s",
-            datefmt="%Y-%m-%dT%H:%M:%S%z",
-        )
-        handler.setFormatter(formatter)
-        logger.addHandler(handler)
 
     return logger

--- a/data/update.py
+++ b/data/update.py
@@ -5,6 +5,7 @@
 # Run with:
 #   python -m data.update
 
+import logging
 import subprocess
 import typing
 
@@ -93,9 +94,10 @@ def scan_domains(
 
 ## Utils function for shelling out.
 def shell_out(command, env=None):
+    logpipe = logger.LogPipe(LOGGER, logging.INFO)
     try:
         LOGGER.info("[cmd] %s", str.join(" ", command))
-        response = subprocess.check_output(command, shell=False, env=env)
+        response = subprocess.check_output(command, shell=False, stderr=logpipe, env=env)
         output = str(response, encoding="UTF-8")
         LOGGER.info(output)
         return output


### PR DESCRIPTION
This PR refactors how the logging is handled in the tracker so that instead of each logger getting it's own streamhandler, we attach all handlers to the root logger, and let log propagation handle the rest as mentioned in the python documentation
> [...A common scenario is to attach handlers only to the root logger, and to let propagation take care of the rest...](https://docs.python.org/3/library/logging.html#logging.Logger.propagate)

This PR also adds a class LogPipe to handle capturing output of the `subprocess` calls and redirect it to a logger