### PR TITLE
Signal to invalidate cache

### DIFF
--- a/data/models.py
+++ b/data/models.py
@@ -45,6 +45,16 @@ def _upsert_all(
           .get_collection('meta')\
           .bulk_write(writes)
 
+def _replace(
+        client: pymongo.MongoClient,
+        collection: str,
+        query: typing.Dict,
+        document: typing.Dict,
+        database: typing.Optional[str] = None) -> None:
+
+    client.get_database(database)
+          .get_collection('meta')
+          .replace_one(({"_collection": collection, **query}, document)
 
 def _find(
         client: pymongo.MongoClient,
@@ -74,6 +84,10 @@ class _Collection():
 
     def upsert_all(self, documents: typing.Iterable[typing.Dict], key_column: str) -> None:
         _upsert_all(self._client, self._name, documents, key_column, self._db)
+
+    def replace(self, query: typing.Dict, document: typing.Dict) -> None:
+        _replace(self._client, self._name, query, document, self._db)
+
 
     def all(self) -> typing.Iterable[typing.Dict]:
         return _find(self._client, self._name, {}, self._db)
@@ -116,6 +130,10 @@ class Connection():
     @property
     def ciphers(self) -> _Collection:
         return _Collection(self._client, 'ciphers')
+
+    @property
+    def flags(self) -> _Collection:
+        return _Collection(self._client, 'flags')
 
     def close(self) -> None:
         self._client.close()

--- a/data/models.py
+++ b/data/models.py
@@ -52,9 +52,9 @@ def _replace(
         document: typing.Dict,
         database: typing.Optional[str] = None) -> None:
 
-    client.get_database(database)
-          .get_collection('meta')
-          .replace_one(({"_collection": collection, **query}, document)
+    client.get_database(database)\
+          .get_collection('meta')\
+          .replace_one({"_collection": collection, **query}, document)
 
 def _find(
         client: pymongo.MongoClient,

--- a/data/models.py
+++ b/data/models.py
@@ -54,7 +54,7 @@ def _replace(
 
     client.get_database(database)\
           .get_collection('meta')\
-          .replace_one({"_collection": collection, **query}, document)
+          .replace_one({"_collection": collection, **query}, {"_collection": collection, **document})
 
 def _find(
         client: pymongo.MongoClient,

--- a/data/processing.py
+++ b/data/processing.py
@@ -113,7 +113,6 @@ def run(date: typing.Optional[str], connection_string: str):
     LOGGER.info("Clearing the database.")
     with models.Connection(connection_string) as connection:
         connection.domains.clear()
-        connection.reports.clear()
         connection.organizations.clear()
 
         # Calculate organization-level summaries. Updates `organizations` in-place.
@@ -132,7 +131,10 @@ def run(date: typing.Optional[str], connection_string: str):
 
         # Create top-level summaries.
         LOGGER.info("Creating government-wide totals.")
-        connection.reports.create(report)
+        connection.reports.replace({}, report)
+
+        # Flag that the cache is now invalid
+        connection.flags.replace({}, {"cache": False})
 
     # Print and exit
     print_report(report)

--- a/data/processing.py
+++ b/data/processing.py
@@ -109,31 +109,31 @@ def run(date: typing.Optional[str], connection_string: str):
         results, owners,
     )
 
+    # Calculate organization-level summaries. Updates `organizations` in-place.
+    update_organization_totals(organizations, results)
+
+    # Calculate government-wide summaries.
+    report = full_report(results)
+    report["report_date"] = date
+
     # Reset the database.
-    LOGGER.info("Clearing the database.")
     with models.Connection(connection_string) as connection:
+        LOGGER.info("Clearing the domains.")
         connection.domains.clear()
-        connection.organizations.clear()
-
-        # Calculate organization-level summaries. Updates `organizations` in-place.
-        update_organization_totals(organizations, results)
-
-        # Calculate government-wide summaries.
-        report = full_report(results)
-        report["report_date"] = date
-
         LOGGER.info("Creating all domains.")
         connection.domains.create_all(results[domain_name] for domain_name in sorted_domains)
+
+        LOGGER.info("Clearing organizations.")
+        connection.organizations.clear()
         LOGGER.info("Creating all organizations.")
         connection.organizations.create_all(
             organizations[organization_name] for organization_name in sorted_organizations
         )
 
-        # Create top-level summaries.
-        LOGGER.info("Creating government-wide totals.")
+        LOGGER.info("Replacing government-wide totals.")
         connection.reports.replace({}, report)
 
-        # Flag that the cache is now invalid
+        LOGGER.info("Signal track-web to drop cache")
         connection.flags.replace({}, {"cache": False})
 
     # Print and exit

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -16,3 +16,26 @@ class TestDomains:
         assert len([d for d in connection.domains.all()]) == 5
         connection.domains.clear()
         assert not [d for d in connection.domains.all()]
+
+    def test_upsert_all(self, connection: models.Connection) -> None: # pylint: disable=no-self-use
+        connection.domains.create_all({'test': i, 'other': -i} for i in range(5))
+
+        connection.domains.upsert_all(
+            [{'test': i, 'other': i} for i in range(4)] +[{'test': 7, 'other': -7}],
+            key_column='test'
+        )
+        results = [d for d in connection.domains.all()]
+
+        assert len(results) == 6
+        assert sorted(results, key=lambda d: d['test']) ==  \
+                [{'test': i, 'other': i} for i in range(4)] + \
+                [{'test': 4, 'other': -4}, {'test': 7, 'other': -7}]
+
+
+    def test_replace(self, connection: models.Connection) -> None: # pylint: disable=no-self-use
+        connection.domains.create({'test': 'value'})
+        connection.domains.replace({'test': 'value'}, {'test': 'other_value'})
+        results = [d for d in connection.domains.all()]
+
+        assert len(results) == 1
+        assert results[0] == {'test': 'other_value'}


### PR DESCRIPTION
This PR refactors how the processing stage loads the data into the DB, as well as adding a small document as a signal to track-web that the cache is now invalid.

A similar PR will be made in track-web to look for such a flag if it exists