### PR TITLE
add upsert to _replace

### DIFF
--- a/data/models.py
+++ b/data/models.py
@@ -196,7 +196,7 @@ def _replace(
 
     client.get_database(database)\
           .get_collection('meta')\
-          .replace_one({"_collection": collection, **query}, {"_collection": collection, **document})
+          .replace_one({"_collection": collection, **query}, {"_collection": collection, **document}, upsert=True)
 
 def _find(
         client: pymongo.MongoClient,

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -39,3 +39,9 @@ class TestDomains:
 
         assert len(results) == 1
         assert results[0] == {'test': 'other_value'}
+
+    def test_replace_new(self, connection: models.Connection) -> None: # pylint: disable=no-self-use
+        connection.domains.replace({}, {'test': 'value'})
+        results = [d for d in connection.domains.all()]
+        assert len(results) == 1
+        assert results[0] == {'test': 'value'}


### PR DESCRIPTION
This PR adds a missing `upsert=True` option to the `_replace` function.

The function was meant to have this at the start, but it was missed.