### PR TITLE
remove filler column

### DIFF
--- a/data/preprocess.py
+++ b/data/preprocess.py
@@ -18,7 +18,7 @@ def pull_data(output: str, connection: models.Connection) -> None:
 
         owner_writer = csv.DictWriter(
             owner_file,
-            fieldnames=['domain', 'filler', 'organization_en', 'organization_fr']
+            fieldnames=['domain', 'organization_en', 'organization_fr']
         )
         domain_writer = csv.DictWriter(domain_file, fieldnames=['domain'])
         cipher_writer = csv.DictWriter(cipher_file, fieldnames=['cipher'])

--- a/data/processing.py
+++ b/data/processing.py
@@ -200,8 +200,8 @@ def load_domain_data() -> typing.Tuple[typing.Set, typing.Dict]:
                 continue
 
             domain_name = row[0].lower().strip()
-            organization_name_en = row[2].strip()
-            organization_name_fr = row[3].strip()
+            organization_name_en = row[1].strip()
+            organization_name_fr = row[2].strip()
             organization_slug = slugify.slugify(organization_name_en)
 
             if domain_name not in domain_map:


### PR DESCRIPTION
This PR removes the code around the temporary "filler" column in the owners list.

This column was there because in Pulse, their CSV had some additional columns that were not relevant to us, so they were removed. However since the row values were accessed by index, that messed up the logic. The filler column was a temporary patch to that until I got around to fixing the access logic.

