### PR TITLE
Improve retry

### DIFF
--- a/data/models.py
+++ b/data/models.py
@@ -39,8 +39,13 @@ def _retry_write(
     ) -> None:
     '''Attempt `write_method`(`data`) `times` times'''
 
+    if not times:
+        attempts = itertools.count(1) # unlimited attempts as long as work is being done
+    else:
+        attempts = iter(range(1, times+1))
+
     errors = []
-    for count in range(1, times+1): # Only do {times} attempts to insert
+    for count in attempts:
         try:
             write_method(data)
             break
@@ -48,10 +53,14 @@ def _retry_write(
             # After retrying the insertion, some of the documents were duplicates, this is OK
             break
         except pymongo.errors.BulkWriteError as exc:
+            if sum(exc.details.get(field, 0) for field in ['nInserted', 'nUpserted', 'nMatched', 'nModified', 'nRemoved']) == 0 and not times:
+                # If no work is being done, and we're not doing a fixed number of attempts, halt
+                raise
+
             details = exc.details.get('writeErrors', [])
             if any(error['code'] == REQUEST_RATE_ERROR for error in details):
-                LOGGER.warning('Exceeded RU limit, pausing for %d seconds...', 2*count)
-                sleep(2*count)
+                LOGGER.warning('%d: Exceeded RU limit, pausing...', count)
+                sleep(1)
                 continue
             # Check if all errors were duplicate key errors, if so should be OK
             elif not all(error['code'] == DUPLICATE_KEY_ERROR for error in details):
@@ -61,8 +70,8 @@ def _retry_write(
             # Check if we blew the request rate, if so take a break and try again
             errors.append(exc)
             if exc.code == REQUEST_RATE_ERROR:
-                LOGGER.warning('Exceeded RU limit, pausing for %d seconds...', 2*count)
-                sleep(2*count)
+                LOGGER.warning('%d: Exceeded RU limit, pausing...', count)
+                sleep(1)
             else:
                 raise
         except Exception as exc:
@@ -79,7 +88,8 @@ def _clear_collection(
         database: typing.Optional[str] = None,
         batch_size: typing.Optional[int] = None) -> None:
     if not batch_size:
-        client.get_database(database).get_collection('meta').delete_many({'_collection': name})
+        _retry_write({'_collection': name}, client.get_database(database).get_collection('meta').delete_many, 0)
+        # client.get_database(database).get_collection('meta').delete_many({'_collection': name})
     else:
         collection = client.get_database(database).get_collection('meta')
 


### PR DESCRIPTION
This PR improves the retry logic to better map to how cosmos db behaves.

Currently it will sleep ever increasing amounts of time until it hits the max retry limit. This doesn't really map well to how cosmos behaves, as usually it's not that the previous attempt didn't wait long enough, it's that the limit was simply hit again after inserting more documents.

Now the retry logic will pause for a constant time after each attempt, and the max rate is configurable via environment variable (with the option to have no limit).