### PR TITLE
remove azure cli virtualenv due to size concerns

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,7 @@ jobs:
     working_directory: ~/repo
   build_package:
     docker:
-      - image: cdssnc/tracker-build:0.5.0
+      - image: cdssnc/tracker-build:0.6.0
     working_directory: /opt/apps/tracker/
     steps:
       - checkout

--- a/deploy/build-env.sh
+++ b/deploy/build-env.sh
@@ -18,11 +18,5 @@ pip install -r domain-scan/requirements-scanners.txt
 pip install .
 deactivate
 
-python3.6 -m venv .azure_venv
-. .azure_venv/bin/activate
-pip install --upgrade pip
-pip install azure-cli
-deactivate
-
-tar -czvf tracker.tar.gz .venv .azure_venv domain-scan
-rm -rf .venv .azure_venv domain-scan
+tar -czvf tracker.tar.gz .venv domain-scan
+rm -rf .venv domain-scan


### PR DESCRIPTION
This inclusion increases the package size by nearly 3 times, as such we have decided it is better to ship the azure-cli to application servers another way.