### PR TITLE
Handle trailing newline

### DIFF
--- a/data/processing.py
+++ b/data/processing.py
@@ -299,7 +299,7 @@ def load_domain_data() -> typing.Tuple[typing.Set, typing.Dict]:
     with open(SCAN_DOMAINS_CSV, newline="") as csvfile:
         for row in csv.reader(csvfile):
             if row == []: # deal with trailing newlines..
-                LOGGER.warning("Trailing newline detected in %s.", owner_path)
+                LOGGER.warning("Trailing newline detected in domains.csv.")
                 continue
             if row[0].lower().startswith("domain"):
                 continue

--- a/data/processing.py
+++ b/data/processing.py
@@ -298,6 +298,9 @@ def load_domain_data() -> typing.Tuple[typing.Set, typing.Dict]:
 
     with open(SCAN_DOMAINS_CSV, newline="") as csvfile:
         for row in csv.reader(csvfile):
+            if row == []: # deal with trailing newlines..
+                LOGGER.warning("Trailing newline detected in %s.", owner_path)
+                continue
             if row[0].lower().startswith("domain"):
                 continue
 


### PR DESCRIPTION
Prevents Index Out of Bounds Errors when trailing newline is detected within domains.csv