### PR TITLE
Dev

### DIFF
--- a/data/logger.py
+++ b/data/logger.py
@@ -34,9 +34,3 @@ def get_logger(name: str) -> logging.Logger:
     logger.setLevel(logging.INFO)
 
     return logger
-
-# Log handler for --debug mode
-def debug_logger(file: str):
-    _debug_handler = logging.StreamHandler(file)
-    _debug_handler.setFormatter(_stream_formatter)
-    logging.getLogger().addHandler(_debug_handler)

--- a/data/logger.py
+++ b/data/logger.py
@@ -21,7 +21,6 @@ _stream_handler.setFormatter(_stream_formatter)
 logging.getLogger().addHandler(_syslog_handler)
 logging.getLogger().addHandler(_stream_handler)
 
-
 def unwrap_exception_message(exc: BaseException, join: str = " - ") -> str:
     if exc.__context__:
         if exc.args:
@@ -35,3 +34,9 @@ def get_logger(name: str) -> logging.Logger:
     logger.setLevel(logging.INFO)
 
     return logger
+
+# Log handler for --debug mode
+def debug_logger(file: str):
+    _debug_handler = logging.StreamHandler(file)
+    _debug_handler.setFormatter(_stream_formatter)
+    logging.getLogger().addHandler(_debug_handler)

--- a/data/update.py
+++ b/data/update.py
@@ -89,18 +89,25 @@ def scan_domains(
         full_command += ["--workers=%i" % env.LAMBDA_WORKERS]
 
     if options.get("debug"):
-        full_command += ["2>&1 | tee tracker_debug_output.txt"]
-
-    shell_out(full_command)
+        debug_output = open("tracker_debug_output", "w")
+        debug_output.write("-- START OF OUTPUT --")
+        debug_output.close()
+        shell_out(full_command, debug=True)
+    else:
+        shell_out(full_command)
 
 
 ## Utils function for shelling out.
-def shell_out(command, env=None):
+def shell_out(command, env=None, debug=False):
     try:
         LOGGER.info("[cmd] %s", str.join(" ", command))
         response = subprocess.check_output(command, shell=False, env=env)
         output = str(response, encoding="UTF-8")
         LOGGER.info(output)
+        if(debug):
+            debug_output = open("tracker_debug_output", "a")
+            debug_output.write(output)
+            debug_output.close()
         return output
     except subprocess.CalledProcessError:
         LOGGER.critical("Error running %s.", str(command))

--- a/data/update.py
+++ b/data/update.py
@@ -102,7 +102,6 @@ def shell_out(command, env=None, debug=False):
         LOGGER.info("[cmd] %s", str.join(" ", command))
         if debug:
             shell_cmd = str.join(" ", command)
-            logger.debug_logger("debug_output.txt")
             response = subprocess.check_output(shell_cmd, shell=True, env=env)
         else:
             response = subprocess.check_output(command, shell=False, env=env)

--- a/data/update.py
+++ b/data/update.py
@@ -102,6 +102,7 @@ def shell_out(command, env=None, debug=False):
         LOGGER.info("[cmd] %s", str.join(" ", command))
         if debug:
             shell_cmd = str.join(" ", command)
+            logger.debug_logger("debug_output.txt")
             response = subprocess.check_output(shell_cmd, shell=True, env=env)
         else:
             response = subprocess.check_output(command, shell=False, env=env)

--- a/data/update.py
+++ b/data/update.py
@@ -65,7 +65,6 @@ def scan_domains(
         domains,
         "--scan=%s" % ','.join(scanners),
         "--output=%s" % output,
-        # "--debug", # always capture full output
         "--sort",
         "--meta",
     ]

--- a/data/update.py
+++ b/data/update.py
@@ -88,6 +88,9 @@ def scan_domains(
     if options.get("lambda") and (options.get("serial", None) is None):
         full_command += ["--workers=%i" % env.LAMBDA_WORKERS]
 
+    if options.get("debug"):
+        full_command += ["2>&1 | tee tracker_debug_output.txt"]
+
     shell_out(full_command)
 
 

--- a/data/update.py
+++ b/data/update.py
@@ -89,9 +89,8 @@ def scan_domains(
         full_command += ["--workers=%i" % env.LAMBDA_WORKERS]
 
     if options.get("debug"):
-        debug_output = open("tracker_debug_output", "w")
-        debug_output.write("-- START OF OUTPUT --")
-        debug_output.close()
+        LOGGER.info("Tracker running in debug mode...")
+        full_command += ["2>&1 | tee debug_output.txt"]
         shell_out(full_command, debug=True)
     else:
         shell_out(full_command)
@@ -101,13 +100,13 @@ def scan_domains(
 def shell_out(command, env=None, debug=False):
     try:
         LOGGER.info("[cmd] %s", str.join(" ", command))
-        response = subprocess.check_output(command, shell=False, env=env)
+        if debug:
+            shell_cmd = str.join(" ", command)
+            response = subprocess.check_output(shell_cmd, shell=True, env=env)
+        else:
+            response = subprocess.check_output(command, shell=False, env=env)
         output = str(response, encoding="UTF-8")
         LOGGER.info(output)
-        if(debug):
-            debug_output = open("tracker_debug_output", "a")
-            debug_output.write(output)
-            debug_output.close()
         return output
     except subprocess.CalledProcessError:
         LOGGER.critical("Error running %s.", str(command))


### PR DESCRIPTION
Passing '--debug' as an argument when tracker is run will save the terminal output to a "debug_output.txt" file within the 'tracker' directory. 